### PR TITLE
FEA-124 Fix JSON.stringify problem with FEA-50

### DIFF
--- a/src/hooks/useLocalStorage.test.ts
+++ b/src/hooks/useLocalStorage.test.ts
@@ -9,7 +9,7 @@ describe('useLocalStorage', () => {
     const { result } = renderHook(() => useLocalStorage(key, newValue));
 
     expect(result.current[0]).toEqual(newValue);
-    expect(localStorage.getItem(key)).toEqual(JSON.stringify(newValue));
+    expect(localStorage.getItem(key)).toEqual(newValue);
   });
 
   it('should save item to local storage', () => {
@@ -21,6 +21,6 @@ describe('useLocalStorage', () => {
       result.current[1](newValue);
     });
     expect(result.current[0]).toEqual(newValue);
-    expect(localStorage.getItem(key)).toEqual(JSON.stringify(newValue));
+    expect(localStorage.getItem(key)).toEqual(newValue);
   });
 });

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 const getItem = (key: string) => localStorage.getItem(key);
 
-const setItem = (key: string, value: string) => localStorage.setItem(key, JSON.stringify(value));
+const setItem = (key: string, value: string) => localStorage.setItem(key, value);
 
 const getInitialState = (key: string, defaultValue: string) => getItem(key) || defaultValue;
 


### PR DESCRIPTION
This fix solves problem with localstorage. On refresh local storage Stringify value that already is string so it end up something like `"\"Wroclaw\""`. As we don't store objects or arrays in localstorage my fix was to delete `JSON.stringify` instead of adding `JSON.parse`